### PR TITLE
Enhance time wheel styling

### DIFF
--- a/Ho.html
+++ b/Ho.html
@@ -10,10 +10,13 @@
       --dur-bg: 700ms; --dur-accent: 420ms; --dur-text: 240ms;
       --c1:#e6eef5; --c2:#c9d6e3; --c3:#aeb9c6;
       --acc1:#90a4ae; --acc2:#607d8b; /* 强调渐变起止色 */
-      --accent:#5a6b7a;               /* ��本强调色 */
+      --accent:#5a6b7a;               /* 基础强调色 */
       --text:#1b1f23; --muted:#5b6570;
       --card-bg:rgba(255,255,255,.55); --card-stroke:rgba(0,0,0,.06);
       --shadow:0 10px 30px rgba(15,23,42,.10);
+      --ring-track: color-mix(in srgb, var(--accent) 18%, rgba(255,255,255,.65));
+      --ring-tick: color-mix(in srgb, var(--accent) 35%, rgba(255,255,255,.85));
+      --ring-core: rgba(255,255,255,.88);
       --dur:.45s;
     }
     @media(prefers-reduced-motion:reduce){ :root{ --dur:0s; } }
@@ -67,8 +70,15 @@
     .grid{margin-top:22px;display:grid;grid-template-columns:1fr;gap:clamp(14px,2.4vw,22px)}
     .panel{background:rgba(255,255,255,.6);border:1px solid var(--card-stroke);border-radius:16px;padding:clamp(12px,2vw,18px)}
     .ring-wrap{display:flex;align-items:center;justify-content:center;padding:8px 0}
-    .ring{width:clamp(140px,28vw,240px);height:auto;display:block}
-    .ring text{font-variant-numeric:tabular-nums;font-weight:700;fill:var(--accent)}
+    .ring{width:clamp(140px,28vw,240px);height:auto;display:block;overflow:visible;filter:drop-shadow(0 18px 30px rgba(15,23,42,.22))}
+    .ring text{font-variant-numeric:tabular-nums;font-weight:700;fill:var(--accent);filter:drop-shadow(0 2px 6px rgba(15,23,42,.18));transition:fill var(--dur-text) ease-in-out}
+    .ring tspan.ring-percent{font-size:clamp(24px,5vw,32px);font-weight:800}
+    .ring tspan.ring-state{font-size:12px;letter-spacing:.3em;fill:color-mix(in srgb, var(--accent) 65%, rgba(20,26,31,.36))}
+    .ring .ring-ambient{opacity:.9;transition:opacity var(--dur-accent) ease-in-out}
+    .ring .ring-track{stroke:var(--ring-track);stroke-width:12;fill:none;stroke-linecap:round}
+    .ring .ring-ticks{stroke:var(--ring-tick);stroke-width:2;fill:none;stroke-dasharray:2 9;stroke-linecap:round;opacity:.6}
+    .ring .ring-inner{fill:var(--ring-core);stroke:rgba(255,255,255,.9);stroke-width:.8}
+    .ring .ring-head{fill:var(--acc2);stroke:rgba(255,255,255,.85);stroke-width:.8;transition:opacity var(--dur-accent) ease,transform var(--dur-accent) ease}
 
     /* 弹层 */
     .popover{position:fixed;z-index:20;min-width:240px;max-width:92vw;background:rgba(255,255,255,.96);border:1px solid var(--card-stroke);border-radius:12px;box-shadow:0 12px 40px rgba(15,23,42,.18);padding:10px;opacity:0;transform:scale(.96) translateY(-6px);pointer-events:none;visibility:hidden;transition:opacity .25s ease,transform .25s ease;-webkit-tap-highlight-color:transparent;user-select:none}
@@ -102,7 +112,7 @@ body.bg-fading .fill::before{ opacity:1; }
 
 .meta{ color:var(--accent); transition: color var(--dur-text) ease-in-out; }
 .meta strong{ color:inherit; }
-#ringText{ fill:var(--accent); transition:fill var(--dur-text) ease-in-out; }
+    
 #g1s1, #g1s2{ transition: stop-color var(--dur-accent) ease-in-out; }
 
 </style>
@@ -156,10 +166,24 @@ body.bg-fading .fill::before{ opacity:1; }
                   <stop id="g1s1" offset="0%" stop-color="var(--acc1)"/>
                   <stop id="g1s2" offset="100%" stop-color="var(--acc2)"/>
                 </linearGradient>
+                <radialGradient id="gAmbient" cx="50%" cy="50%" r="55%">
+                  <stop offset="0%" stop-color="var(--acc2)" stop-opacity=".26"/>
+                  <stop offset="65%" stop-color="var(--acc1)" stop-opacity=".08"/>
+                  <stop offset="100%" stop-color="var(--acc1)" stop-opacity="0"/>
+                </radialGradient>
               </defs>
-              <circle cx="60" cy="60" r="52" stroke="rgba(0,0,0,.08)" stroke-width="12" fill="none" />
-              <circle id="arc" cx="60" cy="60" r="52" stroke="url(#g1)" stroke-width="12" fill="none" stroke-linecap="round" stroke-dasharray="326.72" stroke-dashoffset="326.72" transform="rotate(-90 60 60)"/>
-              <text id="ringText" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="18">0%</text>
+              <g class="ring-layers">
+                <circle class="ring-ambient" cx="60" cy="60" r="58" fill="url(#gAmbient)" />
+                <circle class="ring-track" cx="60" cy="60" r="52" transform="rotate(-90 60 60)" />
+                <circle class="ring-ticks" cx="60" cy="60" r="52" transform="rotate(-90 60 60)" />
+                <circle id="arc" cx="60" cy="60" r="52" stroke="url(#g1)" stroke-width="12" fill="none" stroke-linecap="round" stroke-dasharray="326.72" stroke-dashoffset="326.72" transform="rotate(-90 60 60)"/>
+                <circle id="arcHead" class="ring-head" cx="60" cy="8" r="3.8" opacity="0" />
+                <circle class="ring-inner" cx="60" cy="60" r="41" />
+              </g>
+              <text id="ringText" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">
+                <tspan id="ringPct" class="ring-percent" x="50%" dy="-.2em">0%</tspan>
+                <tspan id="ringState" class="ring-state" x="50%" dy="1.6em">假期中</tspan>
+              </text>
             </svg>
           </div>
         </div>
@@ -189,7 +213,7 @@ body.bg-fading .fill::before{ opacity:1; }
     const startLabel=document.getElementById('startLabel'), endLabel=document.getElementById('endLabel');
     const elapsedEl=document.getElementById('elapsed'), remainEl=document.getElementById('remain'), totalEl=document.getElementById('total');
     const badge=document.getElementById('statusBadge');
-    const arc=document.getElementById('arc'), ringText=document.getElementById('ringText');
+    const arc=document.getElementById('arc'), ringPct=document.getElementById('ringPct'), ringState=document.getElementById('ringState'), ringHead=document.getElementById('arcHead');
     const btnTheme=document.getElementById('btn-theme');
     const pop=document.getElementById('pop');
     const themeList=document.getElementById('themeList');
@@ -312,12 +336,30 @@ body.bg-fading .fill::before{ opacity:1; }
       fillEl.style.transform = `scaleX(${p})`; // transform 驱动避免闪烁
       pctEl.textContent=pct.toFixed(1)+'%';
 
-      const offset=ringLen*(1-p); arc.style.strokeDashoffset=String(offset); ringText.textContent=pct.toFixed(0)+'%';
+      const offset=ringLen*(1-p); arc.style.strokeDashoffset=String(offset);
+      ringPct.textContent=pct.toFixed(0)+'%';
+
+      const theta=-Math.PI/2 + p*2*Math.PI;
+      if(p>0){
+        const hx=60 + Math.cos(theta)*R;
+        const hy=60 + Math.sin(theta)*R;
+        ringHead.setAttribute('cx', hx.toFixed(2));
+        ringHead.setAttribute('cy', hy.toFixed(2));
+        ringHead.setAttribute('opacity', p>=1? '0.65':'1');
+        ringHead.setAttribute('r', p>=1? '4.6':'3.8');
+      } else {
+        ringHead.setAttribute('cx','60');
+        ringHead.setAttribute('cy','8');
+        ringHead.setAttribute('r','3.8');
+        ringHead.setAttribute('opacity','0');
+      }
 
       if(!startLabel.textContent) startLabel.textContent=fmtShanghai(state.start);
       if(!endLabel.textContent) endLabel.textContent=fmtShanghai(state.end);
       elapsedEl.textContent=elapsed<0?'未开始':human(elapsed); remainEl.textContent=remain<0?'已结束':human(remain); totalEl.textContent=human(total);
-      badge.textContent = elapsed<0? '等待' : remain<0? '已结束' : '假期中';
+      const status = elapsed<0? '等待' : remain<0? '已结束' : '假期中';
+      badge.textContent = status;
+      ringState.textContent = status;
     }
 
     // —— 启动 ——


### PR DESCRIPTION
## Summary
- add ring-specific theme variables so the countdown wheel inherits accent colors consistently
- restyle the "time wheel" SVG with ambient glow, track, tick marks, and status text for a more polished presentation
- animate the wheel pointer and status text in sync with the countdown updates

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e3e2c35510832485aafc0fc7d6f9d1