### PR TITLE
Remove wheel status badge from time wheel panel

### DIFF
--- a/Ho.html
+++ b/Ho.html
@@ -49,28 +49,35 @@
     #btn-theme:focus-visible{box-shadow:0 0 0 3px color-mix(in srgb, var(--acc2) 40%, transparent), var(--shadow)}
     .icon{width:18px;height:18px}
 
-    .card{width:min(980px,92vw);margin:18px auto;background:var(--card-bg);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);border:1px solid var(--card-stroke);border-radius:20px;box-shadow:var(--shadow);padding:clamp(16px,2.4vw,28px)}
+    .card{width:min(1100px,90vw);margin:24px auto;background:var(--card-bg);-webkit-backdrop-filter:blur(10px);backdrop-filter:blur(10px);border:1px solid var(--card-stroke);border-radius:22px;box-shadow:var(--shadow);padding:clamp(18px,2.6vw,32px)}
 
     .topline{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:10px;flex-wrap:nowrap;overflow:hidden}
     .range{color:var(--muted);font-size:14px;display:flex;flex-wrap:wrap;gap:10px 16px;flex:1 1 auto;min-width:0}
     .badge{flex:0 0 auto;display:inline-flex;align-items:center;justify-content:center;white-space:nowrap;padding:6px 10px;border-radius:999px;background:rgba(0,0,0,.06);color:var(--accent);border:1px solid var(--card-stroke)}
 
-    .countdown{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:clamp(8px,2vw,16px);align-items:stretch;margin:8px 0 18px}
-    .unit{background:rgba(255,255,255,.6);border:1px solid var(--card-stroke);border-radius:16px;padding:clamp(12px,2vw,18px);display:grid;grid-template-rows:1fr auto;place-items:center;min-height:110px}
-    .num{display:flex;gap:.06em;line-height:1;font-variant-numeric:tabular-nums;font-feature-settings:"tnum" on;font-weight:800;font-size:clamp(28px,7vw,64px)}
-    .digit{display:inline-block;min-width:.66em;text-align:center;will-change:transform,opacity}
-    .label{color:var(--muted);font-size:13px;letter-spacing:.2px}
+    .countdown{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:clamp(12px,2vw,20px);align-items:stretch;margin:12px 0 22px}
+    .unit{background:rgba(255,255,255,.6);border:1px solid var(--card-stroke);border-radius:18px;padding:clamp(14px,2.2vw,22px);display:grid;grid-template-rows:1fr auto;place-items:center;min-height:120px;box-shadow:0 12px 22px rgba(15,23,42,.06)}
+    .num{display:flex;gap:.06em;line-height:1;font-variant-numeric:tabular-nums;font-feature-settings:"tnum" on;font-weight:800;font-size:clamp(32px,6.4vw,68px)}
+    .digit{display:inline-block;min-width:.66em;text-align:center;will-change:transform,opacity;text-shadow:0 6px 12px rgba(15,23,42,.08)}
+    .label{color:var(--muted);font-size:13px;letter-spacing:.26px;text-transform:uppercase}
 
-    .progress{margin:6px 0 2px}
-    .bar{position:relative;height:14px;background:rgba(255,255,255,.65);border:1px solid var(--card-stroke);border-radius:999px;overflow:hidden}
+    .progress{margin:10px 0 4px}
+    .bar{position:relative;height:16px;background:rgba(255,255,255,.7);border:1px solid var(--card-stroke);border-radius:999px;overflow:hidden}
     /* 进度条颜色跟随主题 */
     .fill{height:100%;width:100%;background:linear-gradient(90deg,var(--acc1),var(--acc2));transform-origin:left center;transform:scaleX(0);will-change:transform;transition:transform .6s ease}
-    .meta{margin-top:8px;display:flex;flex-wrap:wrap;align-items:center;gap:10px 16px;font-size:13px;color:var(--muted)} .meta strong{color:var(--text)}
+    .meta{margin-top:10px;display:flex;flex-wrap:wrap;align-items:center;gap:12px 20px;font-size:13px;color:var(--muted)} .meta strong{color:var(--text)}
 
-    .grid{margin-top:22px;display:grid;grid-template-columns:1fr;gap:clamp(14px,2.4vw,22px)}
-    .panel{background:rgba(255,255,255,.6);border:1px solid var(--card-stroke);border-radius:16px;padding:clamp(12px,2vw,18px)}
-    .ring-wrap{display:flex;align-items:center;justify-content:center;padding:8px 0}
-    .ring{width:clamp(140px,28vw,240px);height:auto;display:block;overflow:visible;filter:drop-shadow(0 18px 30px rgba(15,23,42,.22))}
+    .grid{margin-top:24px;display:grid;grid-template-columns:1fr;gap:clamp(16px,2.6vw,26px)}
+    .panel{background:rgba(255,255,255,.6);border:1px solid var(--card-stroke);border-radius:18px;padding:clamp(16px,2.4vw,24px)}
+    .panel h3{margin:0;font-size:15px;letter-spacing:.2px;font-weight:700;color:var(--accent)}
+    .wheel-panel{position:relative;overflow:hidden;padding:clamp(20px,2.6vw,30px);border-radius:24px;background:linear-gradient(150deg,rgba(255,255,255,.94),rgba(255,255,255,.72));box-shadow:0 26px 46px rgba(15,23,42,.14);border:1px solid color-mix(in srgb,var(--accent) 12%,rgba(255,255,255,.6));grid-column:1/-1}
+    .wheel-panel::before{content:"";position:absolute;inset:-30% 30% auto -30%;height:220%;background:radial-gradient(circle at 20% 20%,color-mix(in srgb,var(--accent) 18%,rgba(255,255,255,.9)) 0%,rgba(255,255,255,0) 62%);opacity:.55;pointer-events:none;filter:blur(0.4px)}
+    .wheel-panel::after{content:"";position:absolute;inset:auto -20% -45% 40%;height:220%;background:radial-gradient(circle,color-mix(in srgb,var(--accent) 12%,rgba(255,255,255,.92)) 0%,rgba(255,255,255,0) 70%);opacity:.6;pointer-events:none;}
+    .wheel-head{position:relative;display:flex;align-items:center;justify-content:center;gap:16px;margin-bottom:clamp(16px,1.8vw,22px)}
+    .wheel-grid{position:relative;display:flex;align-items:center;justify-content:center}
+    .ring-wrap{position:relative;display:flex;align-items:center;justify-content:center;padding:0}
+    .ring-wrap::before{content:"";position:absolute;inset:auto 14% -4% 14%;height:60px;border-radius:50%;background:radial-gradient(circle,rgba(15,23,42,.22),rgba(15,23,42,0));opacity:.55;filter:blur(8px);z-index:0}
+    .ring{position:relative;z-index:1;width:clamp(180px,28vw,280px);height:auto;display:block;overflow:visible;filter:drop-shadow(0 16px 28px rgba(15,23,42,.18))}
     .ring text{font-variant-numeric:tabular-nums;font-weight:700;fill:var(--accent);filter:drop-shadow(0 2px 6px rgba(15,23,42,.18));transition:fill var(--dur-text) ease-in-out}
     .ring tspan.ring-percent{font-size:clamp(24px,5vw,32px);font-weight:800}
     .ring tspan.ring-state{font-size:12px;letter-spacing:.3em;fill:color-mix(in srgb, var(--accent) 65%, rgba(20,26,31,.36))}
@@ -100,6 +107,40 @@
     .digit.is-ticking{animation:tick var(--dur) ease}
 
     @media(max-width:720px){.countdown{grid-template-columns:repeat(2,minmax(0,1fr))}}
+
+    @media(min-width:960px){
+      body{font-size:16px;}
+      header{padding:28px 40px;}
+      header h1{font-size:32px;letter-spacing:.6px;}
+      #btn-theme{top:18px;right:36px;padding:10px 14px;font-size:14px;border-radius:14px;}
+      .card{width:min(1180px,84vw);padding:40px 48px;border-radius:26px;gap:24px;}
+      .topline{gap:28px;margin-bottom:18px;}
+      .range{font-size:15px;gap:12px 22px;}
+      .badge{font-size:15px;padding:8px 18px;}
+      .countdown{gap:24px;margin:20px 0 28px;}
+      .unit{padding:28px 24px;border-radius:22px;min-height:168px;}
+      .num{font-size:clamp(40px,3vw,80px);}
+      .label{font-size:15px;letter-spacing:.36px;}
+      .bar{height:20px;}
+      .meta{font-size:14px;gap:14px 28px;}
+      .grid{grid-template-columns:1.2fr .8fr;align-items:stretch;}
+      .panel{padding:30px;border-radius:22px;}
+      .wheel-panel{padding:36px;border-radius:26px;}
+      .wheel-grid{justify-content:center;}
+      .ring{width:clamp(240px,22vw,340px);}
+    }
+
+    @media(min-width:1360px){
+      body{font-size:17px;}
+      header h1{font-size:36px;}
+      .card{width:min(1280px,78vw);padding:48px 64px;}
+      .topline{margin-bottom:24px;}
+      .countdown{gap:28px;}
+      .unit{padding:32px 28px;min-height:188px;}
+      .meta{font-size:15px;}
+      .grid{gap:32px;grid-template-columns:repeat(2,minmax(0,1fr));}
+      .wheel-panel{padding:42px;border-radius:28px;}
+    }
   
 /* === 仅动画增强：进度条颜色 cross-fade + 文本统一成主题强调色 === */
 .fill{ position:relative; }
@@ -157,10 +198,13 @@ body.bg-fading .fill::before{ opacity:1; }
       </section>
 
       <section class="grid">
-        <div class="panel">
-          <h3 style="margin:0 0 10px;font-size:16px">时光之轮</h3>
-          <div class="ring-wrap">
-            <svg class="ring" viewBox="0 0 120 120" role="img" aria-label="时光之轮">
+        <div class="panel wheel-panel">
+          <div class="wheel-head">
+            <h3>时光之轮</h3>
+          </div>
+          <div class="wheel-grid">
+            <div class="ring-wrap">
+              <svg class="ring" viewBox="0 0 120 120" role="img" aria-label="时光之轮">
               <defs>
                 <linearGradient id="g1" x1="0%" y1="0%" x2="100%" y2="0%">
                   <stop id="g1s1" offset="0%" stop-color="var(--acc1)"/>
@@ -184,7 +228,8 @@ body.bg-fading .fill::before{ opacity:1; }
                 <tspan id="ringPct" class="ring-percent" x="50%" dy="-.2em">0%</tspan>
                 <tspan id="ringState" class="ring-state" x="50%" dy="1.6em">假期中</tspan>
               </text>
-            </svg>
+              </svg>
+            </div>
           </div>
         </div>
       </section>
@@ -356,7 +401,13 @@ body.bg-fading .fill::before{ opacity:1; }
 
       if(!startLabel.textContent) startLabel.textContent=fmtShanghai(state.start);
       if(!endLabel.textContent) endLabel.textContent=fmtShanghai(state.end);
-      elapsedEl.textContent=elapsed<0?'未开始':human(elapsed); remainEl.textContent=remain<0?'已结束':human(remain); totalEl.textContent=human(total);
+      const elapsedText = elapsed<0?'未开始':human(elapsed);
+      const remainText = remain<0?'已结束':human(remain);
+      const totalText = human(total);
+      elapsedEl.textContent=elapsedText;
+      remainEl.textContent=remainText;
+      totalEl.textContent=totalText;
+
       const status = elapsed<0? '等待' : remain<0? '已结束' : '假期中';
       badge.textContent = status;
       ringState.textContent = status;


### PR DESCRIPTION
## Summary
- remove the wheel panel status pill so only the centered heading remains
- center the wheel panel header layout now that the badge is gone
- drop the script hook that updated the removed status element

## Testing
- Manual visual verification at 1440px viewport

------
https://chatgpt.com/codex/tasks/task_e_68e46c9bdc6c8324ba101ac5d60e3e31