### PR TITLE
Align SVG gradient with CSS variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,8 +61,8 @@
               <svg class="ring" viewBox="0 0 120 120" role="img" aria-label="时光之轮">
                 <defs>
                   <linearGradient id="g1" x1="0%" y1="0%" x2="100%" y2="0%">
-                    <stop id="g1s1" offset="0%" stop-color="var(--acc1)" />
-                    <stop id="g1s2" offset="100%" stop-color="var(--acc2)" />
+                    <stop id="g1s1" offset="0%" stop-color="var(--acc1_next, var(--acc1))" />
+                    <stop id="g1s2" offset="100%" stop-color="var(--acc2_next, var(--acc2))" />
                   </linearGradient>
                   <radialGradient id="gAmbient" cx="50%" cy="50%" r="55%">
                     <stop offset="0%" stop-color="var(--acc2)" stop-opacity=".26" />

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -58,13 +58,6 @@ function applyTheme(themeId) {
 
   setVar('--accent', accent);
 
-  const stop1 = document.getElementById('g1s1');
-  const stop2 = document.getElementById('g1s2');
-  if (stop1 && stop2) {
-    stop1.setAttribute('stop-color', acc1);
-    stop2.setAttribute('stop-color', acc2);
-  }
-
   const duration = parseDuration(getComputedStyle(document.documentElement).getPropertyValue('--dur-bg'));
   window.clearTimeout(fadeTimer);
   fadeTimer = window.setTimeout(() => commitThemeVariables(theme), duration);


### PR DESCRIPTION
## Summary
- switch the g1 gradient stops to use the accent CSS variables (with _next fallbacks)
- remove the inline gradient stop updates in the theme application script so the SVG now follows the CSS transition

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4c313bb9c8324a6f2b691073d76f3