### PR TITLE
Restore circular drop shadow while preserving flicker fix

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -272,6 +272,30 @@ body.bg-fading .fill::before {
   opacity: 1;
 }
 
+/* During background crossfade, freeze heavy layers until the new theme is committed */
+body.bg-fading,
+body.bg-fading .card,
+body.bg-fading .unit,
+body.bg-fading .panel,
+body.bg-fading .badge,
+body.bg-fading .preview,
+body.bg-fading .bar,
+body.bg-fading .fill {
+  transition: none !important;
+}
+
+/* 在主题 cross-fade 期间，禁用轮子上的滤镜与过渡，避免闪烁 */
+body.bg-fading .ring,
+body.bg-fading .ring-wrap::before,
+body.bg-fading .ring text {
+  filter: none !important;
+}
+
+body.bg-fading .ring,
+body.bg-fading .ring * {
+  transition: none !important;
+}
+
 .meta {
   margin-top: 10px;
   display: flex;
@@ -318,6 +342,9 @@ body.bg-fading .fill::before {
   box-shadow: 0 26px 46px rgba(15, 23, 42, 0.14);
   border: 1px solid color-mix(in srgb, var(--accent) 12%, rgba(255, 255, 255, 0.6));
   grid-column: 1 / -1;
+  isolation: isolate;
+  contain: paint;
+  transform: translateZ(0);
 }
 
 .wheel-panel::before {
@@ -363,6 +390,7 @@ body.bg-fading .fill::before {
   align-items: center;
   justify-content: center;
   padding: 0;
+  box-shadow: none;
 }
 
 .ring-wrap::before {
@@ -384,6 +412,7 @@ body.bg-fading .fill::before {
   height: auto;
   display: block;
   overflow: visible;
+  /* 按形状投影，圆形阴影 */
   filter: drop-shadow(0 16px 28px rgba(15, 23, 42, 0.18));
 }
 


### PR DESCRIPTION
## Summary
- restore the ring's SVG drop shadow so the shadow follows the circular silhouette
- keep the theme cross-fade stable by disabling the ring and text filters during transitions

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e525c7193083248aa61ae518bcf777