### PR TITLE
Fix ring shadow and head theme transitions

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -290,11 +290,6 @@ body.bg-fading .ring-wrap::before {
   filter: none !important;
 }
 
-body.bg-fading .ring,
-body.bg-fading .ring * {
-  transition: none !important;
-}
-
 .meta {
   margin-top: 10px;
   display: flex;
@@ -389,7 +384,7 @@ body.bg-fading .ring * {
   align-items: center;
   justify-content: center;
   padding: 0;
-  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.18);
+  box-shadow: none;
 }
 
 .ring-wrap::before {
@@ -411,7 +406,7 @@ body.bg-fading .ring * {
   height: auto;
   display: block;
   overflow: visible;
-  filter: none;
+  filter: drop-shadow(0 16px 28px rgba(15, 23, 42, 0.18));
 }
 
 .ring text {
@@ -461,10 +456,15 @@ body.bg-fading .ring * {
 }
 
 .ring .ring-head {
-  fill: var(--acc2);
+  color: var(--acc2);
+  fill: currentColor;
   stroke: rgba(255, 255, 255, 0.85);
   stroke-width: 0.8;
-  transition: opacity var(--dur-accent) ease, transform var(--dur-accent) ease;
+  transition: color var(--dur-accent) ease,
+              fill var(--dur-accent) ease,
+              stroke var(--dur-accent) ease,
+              opacity var(--dur-accent) ease,
+              transform var(--dur-accent) ease;
 }
 
 .popover {


### PR DESCRIPTION
## Summary
- restore the SVG drop shadow for the countdown ring while removing the container box shadow to eliminate rectangular artifacts
- keep only filter suppression during theme cross-fades so transitions remain active
- add color-based transitions to the ring head for smooth theme changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e53da8128c8324a9686486ce3e5dbf