### PR TITLE
Restyle theme button with glass icon look

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,20 @@
   <div class="wrap">
     <header>
       <h1 id="pageTitle">国庆·中秋</h1>
-      <button id="btn-theme" title="主题/颜色">
-        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M12 22a7 7 0 0 1 0-14 5 5 0 0 1 5 5 2 2 0 0 0 2 2h1a2 2 0 0 1 0 4h-1a7 7 0 0 1-7 3Z" />
-          <circle cx="6.5" cy="12.5" r="1.5" />
-          <circle cx="9.5" cy="7.5" r="1.5" />
-          <circle cx="14.5" cy="7.5" r="1.5" />
-          <circle cx="17.5" cy="12.5" r="1.5" />
-        </svg>
-        <span class="theme-label">主题</span>
+      <button id="btn-theme" class="icon-btn" type="button" title="主题/颜色">
+        <span class="icon-btn__back"></span>
+        <span class="icon-btn__front">
+          <span class="icon-btn__icon" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M12 22a7 7 0 0 1 0-14 5 5 0 0 1 5 5 2 2 0 0 0 2 2h1a2 2 0 0 1 0 4h-1a7 7 0 0 1-7 3Z" />
+              <circle cx="6.5" cy="12.5" r="1.5" />
+              <circle cx="9.5" cy="7.5" r="1.5" />
+              <circle cx="14.5" cy="7.5" r="1.5" />
+              <circle cx="17.5" cy="12.5" r="1.5" />
+            </svg>
+          </span>
+        </span>
+        <span class="icon-btn__label">主题</span>
       </button>
       <div class="popover" id="pop" role="listbox" aria-label="选择主题">
         <div class="theme-list" id="themeList"></div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,44 +105,91 @@ header h1 {
   letter-spacing: 0.4px;
 }
 
-#btn-theme {
+#btn-theme.icon-btn {
   position: absolute;
   right: 20px;
   top: 12px;
   appearance: none;
-  border: 1px solid var(--card-stroke);
-  background: rgba(255, 255, 255, 0.7);
-  border-radius: 12px;
-  padding: 8px 10px;
+  border: none;
+  background: none;
+  padding: 0;
   cursor: pointer;
-  box-shadow: var(--shadow);
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+  display: grid;
+  gap: 10px;
+  justify-items: center;
+  color: inherit;
+  font: inherit;
   outline: none;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+  transition: filter 0.25s ease;
 }
 
-#btn-theme:hover {
-  filter: brightness(0.98);
-}
-
-#btn-theme:focus {
+#btn-theme.icon-btn:focus {
   outline: none;
 }
 
-#btn-theme:focus-visible {
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--acc2) 40%, transparent), var(--shadow);
+#btn-theme .icon-btn__back {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: linear-gradient(135deg, var(--acc1), var(--acc2));
+  opacity: 0.85;
+  filter: blur(18px);
+  transform: scale(0.88);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.icon {
-  width: 18px;
-  height: 18px;
+#btn-theme .icon-btn__front {
+  position: relative;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
-.theme-label {
-  font-size: 13px;
+#btn-theme .icon-btn__icon {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent);
+}
+
+#btn-theme .icon-btn__icon svg {
+  width: 28px;
+  height: 28px;
+}
+
+#btn-theme .icon-btn__label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-align: center;
+  color: #1f2933;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.7);
+}
+
+#btn-theme.icon-btn:hover .icon-btn__front,
+#btn-theme.icon-btn:focus-visible .icon-btn__front {
+  transform: translateY(-3px);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.24);
+}
+
+#btn-theme.icon-btn:hover .icon-btn__back,
+#btn-theme.icon-btn:focus-visible .icon-btn__back {
+  transform: scale(0.94);
+  opacity: 1;
+}
+
+#btn-theme.icon-btn:focus-visible .icon-btn__front {
+  border-color: color-mix(in srgb, var(--accent) 55%, rgba(255, 255, 255, 0.7));
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 32%, transparent), 0 16px 32px rgba(15, 23, 42, 0.24);
 }
 
 .card {
@@ -607,12 +654,9 @@ body,
     letter-spacing: 0.6px;
   }
 
-  #btn-theme {
+  #btn-theme.icon-btn {
     top: 18px;
     right: 36px;
-    padding: 10px 14px;
-    font-size: 14px;
-    border-radius: 14px;
   }
 
   .card {


### PR DESCRIPTION
## Summary
- restyle the header theme toggle to use the provided glass icon button structure and animation
- restore the popover and theme list implementation so all other theme picker behaviors remain unchanged

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5a96671e883249d66773992ad16e1