### PR TITLE
Set default theme to 松釉青灰

### DIFF
--- a/config/themes.js
+++ b/config/themes.js
@@ -5,4 +5,4 @@ export const THEMES = [
   { id: 'ink-hill', name: '墨兰远山', bg: ['#eef1f0', '#d5dbd9', '#bcc6c2'], acc: ['#9aa7a2', '#6a7f78'], accent: '#556963' },
 ];
 
-export const DEFAULT_THEME_ID = THEMES[0].id;
+export const DEFAULT_THEME_ID = 'sage';


### PR DESCRIPTION
## Summary
- set the default theme identifier to the 松釉青灰 (sage) palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b8f955b88324a08f7bb9e2b831c8