### PR TITLE
Add New Year default countdown and time panel drawer

### DIFF
--- a/config/events.js
+++ b/config/events.js
@@ -1,9 +1,11 @@
+import { nextNewYearRange, octRange, SHANGHAI_OFFSET_MIN, MIN } from '../utils/time.js';
+
 export const EVENTS = [
   {
     id: 'national-day-2025',
     name: '国庆·中秋',
     start: '2025-10-01T00:00:00+08:00',
-    end: '2025-10-08T23:59:59+08:00',
+    end: '2025-10-08T00:00:00+08:00',
     statusLabels: {
       before: '等待',
       during: '假期中',
@@ -12,10 +14,49 @@ export const EVENTS = [
   },
 ];
 
-export const DEFAULT_EVENT_ID = EVENTS[0].id;
+const getShanghaiYear = (now) => {
+  const timestamp = now instanceof Date ? now.getTime() : Number(now) || Date.now();
+  return new Date(timestamp + SHANGHAI_OFFSET_MIN * MIN).getUTCFullYear();
+};
 
-export function getActiveEvent(search = window.location.search) {
+export function buildNewYear(now = new Date()) {
+  const { start, end } = nextNewYearRange(now);
+  return {
+    id: 'new-year',
+    name: '元旦',
+    start: start.toISOString(),
+    end: end.toISOString(),
+    statusLabels: {
+      before: '等待',
+      during: '今天',
+      after: '已结束',
+    },
+  };
+}
+
+export function buildOct(now = new Date()) {
+  const year = getShanghaiYear(now);
+  const { start, end } = octRange(year);
+  return {
+    id: `national-day-${year}`,
+    name: '国庆·中秋',
+    start: start.toISOString(),
+    end: end.toISOString(),
+    statusLabels: {
+      before: '等待',
+      during: '假期中',
+      after: '已结束',
+    },
+  };
+}
+
+export function getActiveEvent(search = window.location.search, now = new Date()) {
   const params = new URLSearchParams(search);
-  const eventId = params.get('event') || DEFAULT_EVENT_ID;
-  return EVENTS.find((event) => event.id === eventId) ?? EVENTS[0];
+  const eventId = params.get('event');
+  if (!eventId) {
+    return buildNewYear(now);
+  }
+
+  const matched = EVENTS.find((event) => event.id === eventId);
+  return matched ?? buildNewYear(now);
 }

--- a/index.html
+++ b/index.html
@@ -3,13 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>国庆·中秋</title>
+  <title>元旦</title>
   <link rel="stylesheet" href="./styles/main.css" />
 </head>
 <body>
   <div class="wrap">
     <header>
-      <h1 id="pageTitle">国庆·中秋</h1>
+      <button id="btn-drawer" type="button" title="时间面板" aria-label="时间面板">☰</button>
+      <h1 id="pageTitle">元旦</h1>
       <button id="btn-theme" title="主题/颜色">
         <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22a7 7 0 0 1 0-14 5 5 0 0 1 5 5 2 2 0 0 0 2 2h1a2 2 0 0 1 0 4h-1a7 7 0 0 1-7 3Z" />
@@ -24,6 +25,31 @@
         <div class="theme-list" id="themeList"></div>
       </div>
     </header>
+
+    <div id="backdrop" class="backdrop" hidden></div>
+    <aside id="drawer" class="drawer" aria-label="时间面板" hidden>
+      <div class="drawer-header">
+        <h2>时间面板</h2>
+      </div>
+      <div class="drawer-body">
+        <section class="drawer-section">
+          <h3 class="drawer-group">常驻</h3>
+          <div class="panel-card">
+            <div class="panel-card-title">下次周日</div>
+            <div id="sunValue" class="panel-card-value" aria-live="polite">--</div>
+            <div id="sunDesc" class="panel-card-desc">--</div>
+          </div>
+        </section>
+        <section class="drawer-section">
+          <h3 class="drawer-group">节日</h3>
+          <div class="panel-card">
+            <div class="panel-card-title">国庆·中秋</div>
+            <div id="octValue" class="panel-card-value" aria-live="polite">--</div>
+            <div id="octDesc" class="panel-card-desc">--</div>
+          </div>
+        </section>
+      </div>
+    </aside>
 
     <main class="card">
       <div class="topline">

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,10 +1,12 @@
 import { initThemePicker } from './theme.js';
 import { startCountdown } from './countdown.js';
-import { getActiveEvent } from '../config/events.js';
+import { getActiveEvent, buildNewYear } from '../config/events.js';
 import { elements } from './dom.js';
+import { initDrawer, startPanel } from './panel.js';
 
 function boot() {
-  const event = getActiveEvent();
+  const now = new Date();
+  const event = getActiveEvent(window.location.search, now) ?? buildNewYear(now);
   if (event) {
     document.title = event.name;
     if (elements.pageTitle) {
@@ -14,6 +16,8 @@ function boot() {
 
   initThemePicker();
   startCountdown(event);
+  initDrawer();
+  startPanel();
 }
 
 document.addEventListener('DOMContentLoaded', boot);

--- a/scripts/dom.js
+++ b/scripts/dom.js
@@ -29,4 +29,15 @@ export const elements = {
     list: document.getElementById('themeList'),
   },
   pageTitle: document.getElementById('pageTitle'),
+  drawer: {
+    root: document.getElementById('drawer'),
+    backdrop: document.getElementById('backdrop'),
+    button: document.getElementById('btn-drawer'),
+  },
+  panel: {
+    sunValue: document.getElementById('sunValue'),
+    sunDesc: document.getElementById('sunDesc'),
+    octValue: document.getElementById('octValue'),
+    octDesc: document.getElementById('octDesc'),
+  },
 };

--- a/scripts/panel.js
+++ b/scripts/panel.js
@@ -1,0 +1,157 @@
+import { elements } from './dom.js';
+import {
+  breakdownDuration,
+  formatShanghai,
+  nextSundayRange,
+  rangeStatus,
+} from '../utils/time.js';
+import { buildOct } from '../config/events.js';
+
+const pad = (value) => String(Math.max(0, value)).padStart(2, '0');
+
+const toLabel = (date) => formatShanghai(date).slice(0, 16);
+
+const formatCountdown = (duration) => {
+  const safe = Math.max(0, duration);
+  const { d, h, m, s } = breakdownDuration(safe);
+  return `${d} 天 ${pad(h)}:${pad(m)}:${pad(s)}`;
+};
+
+const setText = (element, text) => {
+  if (!element) return;
+  element.textContent = text;
+};
+
+function renderSunday(now) {
+  const { panel } = elements;
+  if (!panel) return;
+
+  const { start, end } = nextSundayRange(now);
+  const { status } = rangeStatus(now, start, end);
+
+  if (status === 'during') {
+    const diff = end.getTime() - now.getTime();
+    setText(panel.sunValue, `放假中，距离结束还有 ${formatCountdown(diff)}`);
+    setText(panel.sunDesc, `结束：${toLabel(end)}`);
+    return;
+  }
+
+  if (status === 'after') {
+    const diff = now.getTime() - end.getTime();
+    setText(panel.sunValue, `已经过去 ${formatCountdown(diff)}`);
+    setText(panel.sunDesc, `结束：${toLabel(end)}`);
+    return;
+  }
+
+  const diff = start.getTime() - now.getTime();
+  setText(panel.sunValue, `还有 ${formatCountdown(diff)}`);
+  setText(panel.sunDesc, `下次周日：${toLabel(start)}`);
+}
+
+function renderOct(now) {
+  const { panel } = elements;
+  if (!panel) return;
+
+  const event = buildOct(now);
+  const start = new Date(event.start);
+  const end = new Date(event.end);
+  const { status } = rangeStatus(now, start, end);
+
+  if (status === 'during') {
+    const diff = end.getTime() - now.getTime();
+    setText(panel.octValue, `放假中，距离结束还有 ${formatCountdown(diff)}`);
+    setText(panel.octDesc, `结束：${toLabel(end)}`);
+    return;
+  }
+
+  if (status === 'after') {
+    const diff = now.getTime() - end.getTime();
+    setText(panel.octValue, `已经过去 ${formatCountdown(diff)}`);
+    setText(panel.octDesc, `结束：${toLabel(end)}`);
+    return;
+  }
+
+  const diff = start.getTime() - now.getTime();
+  setText(panel.octValue, `还有 ${formatCountdown(diff)}`);
+  setText(panel.octDesc, `开始：${toLabel(start)}`);
+}
+
+export function initDrawer() {
+  const { drawer } = elements;
+  if (!drawer || !drawer.button) return;
+
+  const { button, root, backdrop } = drawer;
+  let hideTimer = null;
+
+  button.setAttribute('aria-expanded', 'false');
+  button.setAttribute('aria-controls', 'drawer');
+
+  const openDrawer = () => {
+    if (!root) return;
+    if (hideTimer) {
+      clearTimeout(hideTimer);
+      hideTimer = null;
+    }
+    if (root.hidden) root.hidden = false;
+    if (backdrop && backdrop.hidden) backdrop.hidden = false;
+    requestAnimationFrame(() => {
+      root.classList.add('open');
+      if (backdrop) backdrop.classList.add('open');
+    });
+    button.setAttribute('aria-expanded', 'true');
+  };
+
+  const closeDrawer = () => {
+    if (!root) return;
+    root.classList.remove('open');
+    if (backdrop) backdrop.classList.remove('open');
+    button.setAttribute('aria-expanded', 'false');
+    hideTimer = window.setTimeout(() => {
+      if (root && !root.classList.contains('open')) {
+        root.hidden = true;
+      }
+      if (backdrop && !backdrop.classList.contains('open')) {
+        backdrop.hidden = true;
+      }
+      hideTimer = null;
+    }, 280);
+  };
+
+  const toggleDrawer = () => {
+    if (!root) return;
+    if (root.classList.contains('open')) {
+      closeDrawer();
+    } else {
+      openDrawer();
+    }
+  };
+
+  button.addEventListener('click', toggleDrawer);
+
+  if (backdrop) {
+    backdrop.addEventListener('click', closeDrawer);
+  }
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && root && root.classList.contains('open')) {
+      event.preventDefault();
+      closeDrawer();
+      button.focus();
+    }
+  });
+}
+
+export function startPanel() {
+  const render = () => {
+    const now = new Date();
+    renderSunday(now);
+    renderOct(now);
+  };
+
+  render();
+  const kick = 1000 - (Date.now() % 1000);
+  window.setTimeout(() => {
+    render();
+    window.setInterval(render, 1000);
+  }, kick);
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -105,9 +105,9 @@ header h1 {
   letter-spacing: 0.4px;
 }
 
-#btn-theme {
+#btn-theme,
+#btn-drawer {
   position: absolute;
-  right: 20px;
   top: 12px;
   appearance: none;
   border: 1px solid var(--card-stroke);
@@ -124,15 +124,31 @@ header h1 {
   user-select: none;
 }
 
-#btn-theme:hover {
+#btn-theme {
+  right: 20px;
+}
+
+#btn-drawer {
+  left: 20px;
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+  justify-content: center;
+  min-width: 42px;
+}
+
+#btn-theme:hover,
+#btn-drawer:hover {
   filter: brightness(0.98);
 }
 
-#btn-theme:focus {
+#btn-theme:focus,
+#btn-drawer:focus {
   outline: none;
 }
 
-#btn-theme:focus-visible {
+#btn-theme:focus-visible,
+#btn-drawer:focus-visible {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--acc2) 40%, transparent), var(--shadow);
 }
 
@@ -315,6 +331,103 @@ body.bg-fading .fill {
   border: 1px solid var(--card-stroke);
   border-radius: 18px;
   padding: clamp(16px, 2.4vw, 24px);
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(2px);
+  z-index: 30;
+  display: none;
+}
+
+.backdrop.open {
+  display: block;
+}
+
+.drawer {
+  position: fixed;
+  inset: 0 auto 0 0;
+  width: min(320px, 90vw);
+  background: var(--card-bg);
+  border-right: 1px solid var(--card-stroke);
+  box-shadow: var(--shadow);
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+  z-index: 40;
+  padding: 20px 20px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow: hidden;
+  color: var(--text);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+}
+
+.drawer.open {
+  transform: translateX(0);
+}
+
+.drawer-header h2 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--accent);
+}
+
+.drawer-body {
+  overflow-y: auto;
+  padding-right: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.drawer-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.drawer-group {
+  margin: 0;
+  font-size: 14px;
+  letter-spacing: 0.4px;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.panel-card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-stroke);
+  border-radius: 18px;
+  padding: 16px 18px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+.panel-card-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.panel-card-value {
+  font-size: 18px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum' on;
+}
+
+.panel-card-desc {
+  font-size: 13px;
+  color: var(--muted);
 }
 
 .panel h3 {
@@ -607,12 +720,21 @@ body,
     letter-spacing: 0.6px;
   }
 
-  #btn-theme {
+  #btn-theme,
+  #btn-drawer {
     top: 18px;
-    right: 36px;
     padding: 10px 14px;
     font-size: 14px;
     border-radius: 14px;
+  }
+
+  #btn-theme {
+    right: 36px;
+  }
+
+  #btn-drawer {
+    left: 36px;
+    min-width: 48px;
   }
 
   .card {

--- a/utils/time.js
+++ b/utils/time.js
@@ -8,6 +8,11 @@ export const SHANGHAI_OFFSET_MIN = 8 * 60;
 
 const pad = (value) => String(value).padStart(2, '0');
 
+const toTimestamp = (value) => (value instanceof Date ? value.getTime() : value);
+
+const shanghaiDate = (year, month, day, hours = 0, minutes = 0, seconds = 0) =>
+  new Date(Date.UTC(year, month, day, hours, minutes, seconds) - SHANGHAI_OFFSET_MIN * MIN);
+
 export function formatShanghai(date) {
   const offsetDate = new Date(date.getTime() + SHANGHAI_OFFSET_MIN * MIN);
   const year = offsetDate.getUTCFullYear();
@@ -39,4 +44,70 @@ export function humanizeDuration(duration) {
   if (m) parts.push(`${m}分钟`);
   if (!d && !h) parts.push(`${s}秒`);
   return parts.join(' ');
+}
+
+export function startOfDay(date) {
+  const shanghaiNow = new Date(toTimestamp(date) + SHANGHAI_OFFSET_MIN * MIN);
+  const year = shanghaiNow.getUTCFullYear();
+  const month = shanghaiNow.getUTCMonth();
+  const day = shanghaiNow.getUTCDate();
+  return shanghaiDate(year, month, day);
+}
+
+export function addDays(date, amount) {
+  return new Date(toTimestamp(date) + amount * DAY);
+}
+
+export function nextSundayRange(now) {
+  const current = new Date(toTimestamp(now));
+  const shanghaiNow = new Date(current.getTime() + SHANGHAI_OFFSET_MIN * MIN);
+  const day = shanghaiNow.getUTCDay();
+  const startToday = startOfDay(current);
+  const daysUntil = (7 - day) % 7;
+  const start = daysUntil === 0 ? startToday : addDays(startToday, daysUntil);
+  const end = addDays(start, 1);
+  return { start, end };
+}
+
+export function octRange(year) {
+  const start = shanghaiDate(year, 9, 1);
+  const end = shanghaiDate(year, 9, 8);
+  return { start, end };
+}
+
+export function nextNewYearRange(now) {
+  const current = new Date(toTimestamp(now));
+  const shanghaiNow = new Date(current.getTime() + SHANGHAI_OFFSET_MIN * MIN);
+  const year = shanghaiNow.getUTCFullYear();
+  const thisNewYearStart = shanghaiDate(year, 0, 1);
+  const thisNewYearEnd = addDays(thisNewYearStart, 1);
+
+  if (current.getTime() < thisNewYearStart.getTime()) {
+    return { start: thisNewYearStart, end: thisNewYearEnd };
+  }
+
+  if (current.getTime() < thisNewYearEnd.getTime()) {
+    return { start: thisNewYearStart, end: thisNewYearEnd };
+  }
+
+  const nextNewYearStart = shanghaiDate(year + 1, 0, 1);
+  return { start: nextNewYearStart, end: addDays(nextNewYearStart, 1) };
+}
+
+export function rangeStatus(now, start, end) {
+  const nowMs = toTimestamp(now);
+  const startMs = toTimestamp(start);
+  const endMs = toTimestamp(end);
+  const total = Math.max(0, endMs - startMs);
+
+  if (nowMs < startMs) {
+    return { status: 'before', ratio: total ? Math.max(0, (nowMs - startMs) / total) : 0 };
+  }
+
+  if (nowMs >= endMs) {
+    return { status: 'after', ratio: 1 };
+  }
+
+  const ratio = total ? (nowMs - startMs) / total : 0;
+  return { status: 'during', ratio };
 }


### PR DESCRIPTION
## Summary
- set the default homepage countdown to the next New Year while preserving direct national day links
- add a drawer-based time panel showing the upcoming Sunday and the current year's national day status
- extend shared time utilities and styles to drive the new panel content and animations

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e5dc7b23bc8324b55972a817a6573d