### PR TITLE
Implement seasonal homepage switching

### DIFF
--- a/config/events.js
+++ b/config/events.js
@@ -1,62 +1,75 @@
-import { nextNewYearRange, octRange, SHANGHAI_OFFSET_MIN, MIN } from '../utils/time.js';
+import { newYearRange, octRange, nextSundayRange, SHANGHAI_OFFSET_MIN, MIN } from '../utils/time.js';
 
-export const EVENTS = [
-  {
-    id: 'national-day-2025',
-    name: '国庆·中秋',
-    start: '2025-10-01T00:00:00+08:00',
-    end: '2025-10-08T00:00:00+08:00',
-    statusLabels: {
-      before: '等待',
-      during: '假期中',
-      after: '已结束',
-    },
-  },
-];
+const toTimestamp = (value) => (value instanceof Date ? value.getTime() : Number(value) || Date.now());
 
 const getShanghaiYear = (now) => {
-  const timestamp = now instanceof Date ? now.getTime() : Number(now) || Date.now();
+  const timestamp = toTimestamp(now);
   return new Date(timestamp + SHANGHAI_OFFSET_MIN * MIN).getUTCFullYear();
 };
 
+export const HEADLINE_COPY = {
+  'new-year': {
+    before: (event) => `距离${event.title}还有…`,
+    during: (event) => `今天是${event.title}，距离结束还有…`,
+    after: (event) => `${event.title}已结束…`,
+  },
+  'golden-week': {
+    before: (event) => `距离${event.title}还有…`,
+    during: () => '放假中，距离结束还有…',
+    after: (event) => `距离${event.title}结束已经过去…`,
+  },
+  'next-sunday': {
+    before: (event) => `距离${event.title}还有…`,
+    during: () => '放假中（周日），距离结束还有…',
+    after: (event) => `${event.title}已结束…`,
+  },
+};
+
+export const PANEL_COPY = {
+  'new-year': {
+    before: (event) => `距离${event.title}还有`,
+    during: (event) => `今天是${event.title}，距离结束还有`,
+    after: (event) => `${event.title}已结束`,
+  },
+  'golden-week': {
+    before: (event) => `距离${event.title}还有`,
+    during: () => '放假中，距离结束还有',
+    after: (event) => `距离${event.title}结束已经过去`,
+  },
+  'next-sunday': {
+    before: (event) => `距离${event.title}还有`,
+    during: () => '放假中（周日），距离结束还有',
+    after: (event) => `${event.title}已结束`,
+  },
+};
+
 export function buildNewYear(now = new Date()) {
-  const { start, end } = nextNewYearRange(now);
+  const { start, end } = newYearRange(now);
   return {
     id: 'new-year',
-    name: '元旦',
-    start: start.toISOString(),
-    end: end.toISOString(),
-    statusLabels: {
-      before: '等待',
-      during: '今天',
-      after: '已结束',
-    },
+    title: '元旦',
+    start,
+    end,
   };
 }
 
-export function buildOct(now = new Date()) {
+export function buildGoldenWeek(now = new Date()) {
   const year = getShanghaiYear(now);
   const { start, end } = octRange(year);
   return {
-    id: `national-day-${year}`,
-    name: '国庆·中秋',
-    start: start.toISOString(),
-    end: end.toISOString(),
-    statusLabels: {
-      before: '等待',
-      during: '假期中',
-      after: '已结束',
-    },
+    id: 'golden-week',
+    title: '国庆·中秋',
+    start,
+    end,
   };
 }
 
-export function getActiveEvent(search = window.location.search, now = new Date()) {
-  const params = new URLSearchParams(search);
-  const eventId = params.get('event');
-  if (!eventId) {
-    return buildNewYear(now);
-  }
-
-  const matched = EVENTS.find((event) => event.id === eventId);
-  return matched ?? buildNewYear(now);
+export function buildNextSunday(now = new Date()) {
+  const { start, end } = nextSundayRange(now);
+  return {
+    id: 'next-sunday',
+    title: '下次周日',
+    start,
+    end,
+  };
 }

--- a/index.html
+++ b/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>元旦</title>
+  <title>倒计时</title>
   <link rel="stylesheet" href="./styles/main.css" />
 </head>
 <body>
   <div class="wrap">
     <header>
       <button id="btn-drawer" type="button" title="时间面板" aria-label="时间面板">☰</button>
-      <h1 id="pageTitle">元旦</h1>
+      <h1 id="pageTitle">倒计时</h1>
       <button id="btn-theme" title="主题/颜色">
         <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22a7 7 0 0 1 0-14 5 5 0 0 1 5 5 2 2 0 0 0 2 2h1a2 2 0 0 1 0 4h-1a7 7 0 0 1-7 3Z" />
@@ -57,7 +57,7 @@
           <div>开始：<strong id="startLabel"></strong></div>
           <div>结束：<strong id="endLabel"></strong></div>
         </div>
-        <div class="badge" id="statusBadge">假期中</div>
+        <div class="badge" id="statusBadge">等待</div>
       </div>
 
       <section class="countdown" aria-live="polite">
@@ -106,7 +106,7 @@
                 </g>
                 <text id="ringText" x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">
                   <tspan id="ringPct" class="ring-percent" x="50%" dy="-.2em">0%</tspan>
-                  <tspan id="ringState" class="ring-state" x="50%" dy="1.6em">假期中</tspan>
+                  <tspan id="ringState" class="ring-state" x="50%" dy="1.6em">等待</tspan>
                 </text>
               </svg>
             </div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,23 +1,56 @@
 import { initThemePicker } from './theme.js';
-import { startCountdown } from './countdown.js';
-import { getActiveEvent, buildNewYear } from '../config/events.js';
-import { elements } from './dom.js';
-import { initDrawer, startPanel } from './panel.js';
+import { renderCountdown } from './countdown.js';
+import { buildNewYear, buildGoldenWeek, buildNextSunday } from '../config/events.js';
+import { initDrawer, renderPanel } from './panel.js';
+import { addDays } from '../utils/time.js';
 
-function boot() {
-  const now = new Date();
-  const event = getActiveEvent(window.location.search, now) ?? buildNewYear(now);
-  if (event) {
-    document.title = event.name;
-    if (elements.pageTitle) {
-      elements.pageTitle.textContent = event.name;
-    }
+const getTime = (value) => (value instanceof Date ? value.getTime() : new Date(value).getTime());
+
+function withinWindow(now, start, end) {
+  const nowMs = getTime(now);
+  return nowMs >= getTime(start) && nowMs < getTime(end);
+}
+
+export function selectHomeEvent(now = new Date()) {
+  const current = now instanceof Date ? now : new Date(now);
+
+  const newYear = buildNewYear(current);
+  const newYearWindowStart = addDays(newYear.start, -1);
+  if (withinWindow(current, newYearWindowStart, newYear.end)) {
+    return newYear;
   }
 
+  const golden = buildGoldenWeek(current);
+  const goldenWindowStart = addDays(golden.start, -1);
+  const goldenWindowEnd = addDays(golden.end, 1);
+  if (withinWindow(current, goldenWindowStart, goldenWindowEnd)) {
+    return golden;
+  }
+
+  return buildNextSunday(current);
+}
+
+function createTick() {
+  return () => {
+    const now = new Date();
+    const homeEvent = selectHomeEvent(now);
+    renderCountdown(homeEvent, now);
+    renderPanel(now);
+  };
+}
+
+function boot() {
   initThemePicker();
-  startCountdown(event);
   initDrawer();
-  startPanel();
+
+  const tick = createTick();
+  tick();
+
+  const kick = 1000 - (Date.now() % 1000);
+  window.setTimeout(() => {
+    tick();
+    window.setInterval(tick, 1000);
+  }, kick);
 }
 
 document.addEventListener('DOMContentLoaded', boot);

--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -1,14 +1,28 @@
 import { elements } from './dom.js';
-import { breakdownDuration, humanizeDuration, formatShanghai } from '../utils/time.js';
+import { breakdownDuration, humanizeDuration, formatShanghai, rangeStatus } from '../utils/time.js';
+import { HEADLINE_COPY } from '../config/events.js';
 
 const RADIUS = 52;
 const RING_LENGTH = 2 * Math.PI * RADIUS;
 const RING_ANIMATION_DURATION = 420;
 const RING_ANIMATION_EPSILON = 1e-4;
 
+const STATE_BADGE_LABELS = {
+  before: '等待',
+  during: '进行中',
+  after: '已结束',
+};
+
 let ringAnimationFrame = null;
 let ringCurrentRatio = 0;
 let ringInitialized = false;
+
+let activeEventKey = null;
+let activeStart = null;
+let activeEnd = null;
+let activeTitle = '';
+let totalDuration = 0;
+let totalText = '';
 
 const previousDigits = {
   days: '',
@@ -18,6 +32,14 @@ const previousDigits = {
 };
 
 const clamp01 = (value) => Math.min(1, Math.max(0, value));
+
+const toDate = (value) => (value instanceof Date ? value : new Date(value));
+
+function resetDigitsState() {
+  Object.keys(previousDigits).forEach((key) => {
+    previousDigits[key] = '';
+  });
+}
 
 function ensureDigitSlots(container, count) {
   if (!container) return;
@@ -41,7 +63,7 @@ function setDigits(container, key, value, width = 2) {
     const digit = container.children[index];
     if (previousDigits[key].charAt(index) !== char) {
       digit.classList.remove('is-ticking');
-      void digit.offsetWidth; // restart animation
+      void digit.offsetWidth;
       digit.textContent = char;
       digit.classList.add('is-ticking');
     } else if (!digit.textContent) {
@@ -149,74 +171,120 @@ function setRingProgress(ringElements, ratio, statusText) {
   ringAnimationFrame = requestAnimationFrame(step);
 }
 
-function deriveStatus(labels, elapsed, remain) {
-  if (elapsed < 0) return labels.before;
-  if (remain < 0) return labels.after;
-  return labels.during;
+function getHeadline(event, state) {
+  const copy = HEADLINE_COPY[event.id];
+  const builder = copy && copy[state];
+  if (typeof builder === 'function') {
+    return builder(event);
+  }
+
+  if (state === 'after') {
+    return `${event.title ?? ''}已结束…`;
+  }
+  if (state === 'during') {
+    return `${event.title ?? ''}进行中…`;
+  }
+  return `距离${event.title ?? ''}还有…`;
 }
 
-export function startCountdown(event) {
-  if (!event) return;
+function ensureEvent(event) {
+  if (!event) return false;
 
-  const start = new Date(event.start);
-  const end = new Date(event.end);
-  const total = end.getTime() - start.getTime();
-  const totalText = humanizeDuration(total);
-  const statusLabels = {
-    before: '等待',
-    during: '进行中',
-    after: '已结束',
-    ...event.statusLabels,
-  };
+  const start = toDate(event.start);
+  const end = toDate(event.end);
+  const key = `${event.id ?? 'event'}-${start.getTime()}-${end.getTime()}`;
 
-  const { digits, meta, labels, statusBadge, ring } = elements;
+  if (activeEventKey === key) {
+    return true;
+  }
+
+  activeEventKey = key;
+  activeStart = start;
+  activeEnd = end;
+  activeTitle = event.title ?? event.name ?? '';
+  totalDuration = Math.max(0, activeEnd.getTime() - activeStart.getTime());
+  totalText = humanizeDuration(totalDuration);
+
+  const { digits, meta, labels, ring } = elements;
   updateRingGeometry(ring.arc);
   resetRingProgress();
+  resetDigitsState();
 
-  ['days', 'hours', 'minutes', 'seconds'].forEach((key) => {
-    ensureDigitSlots(digits[key], 2);
+  ['days', 'hours', 'minutes', 'seconds'].forEach((keyName) => {
+    ensureDigitSlots(digits[keyName], 2);
   });
 
-  if (labels.start && !labels.start.textContent) {
-    labels.start.textContent = formatShanghai(start);
+  if (labels.start) {
+    labels.start.textContent = formatShanghai(activeStart);
   }
-  if (labels.end && !labels.end.textContent) {
-    labels.end.textContent = formatShanghai(end);
+  if (labels.end) {
+    labels.end.textContent = formatShanghai(activeEnd);
+  }
+  if (meta.total) {
+    meta.total.textContent = totalText;
   }
 
-  const render = () => {
-    const now = Date.now();
-    const elapsed = now - start.getTime();
-    const remain = end.getTime() - now;
+  return true;
+}
 
-    const remainingParts = breakdownDuration(remain);
-    setDigits(digits.days, 'days', remainingParts.d, 2);
-    setDigits(digits.hours, 'hours', remainingParts.h, 2);
-    setDigits(digits.minutes, 'minutes', remainingParts.m, 2);
-    setDigits(digits.seconds, 'seconds', remainingParts.s, 2);
+export function renderCountdown(event, now = new Date()) {
+  if (!ensureEvent(event)) return;
 
-    const ratio = clamp01(elapsed / total);
-    if (meta.fill) {
-      meta.fill.style.transform = `scaleX(${ratio})`;
-    }
-    if (meta.pct) {
-      meta.pct.textContent = `${(Math.round(ratio * 1000) / 10).toFixed(1)}%`;
-    }
+  const current = now instanceof Date ? now : new Date(now);
+  const nowMs = current.getTime();
+  const { digits, meta, statusBadge, ring, pageTitle } = elements;
 
-    const statusText = deriveStatus(statusLabels, elapsed, remain);
-    if (statusBadge) statusBadge.textContent = statusText;
+  const status = rangeStatus(current, { start: activeStart, end: activeEnd });
+  const state = status.state;
 
-    if (meta.elapsed) meta.elapsed.textContent = elapsed < 0 ? '未开始' : humanizeDuration(elapsed);
-    if (meta.remain) meta.remain.textContent = remain < 0 ? '已结束' : humanizeDuration(remain);
-    if (meta.total) meta.total.textContent = totalText;
+  let diffMs = 0;
+  if (state === 'before') {
+    diffMs = activeStart.getTime() - nowMs;
+  } else if (state === 'during') {
+    diffMs = activeEnd.getTime() - nowMs;
+  } else {
+    diffMs = nowMs - activeEnd.getTime();
+  }
 
-    setRingProgress(ring, ratio, statusText);
-  };
+  const remainingParts = breakdownDuration(diffMs);
+  setDigits(digits.days, 'days', remainingParts.d, 2);
+  setDigits(digits.hours, 'hours', remainingParts.h, 2);
+  setDigits(digits.minutes, 'minutes', remainingParts.m, 2);
+  setDigits(digits.seconds, 'seconds', remainingParts.s, 2);
 
-  render();
-  const kick = 1000 - (Date.now() % 1000);
-  window.setTimeout(() => {
-    render();
-    window.setInterval(render, 1000);
-  }, kick);
+  const elapsed = nowMs - activeStart.getTime();
+  const remain = activeEnd.getTime() - nowMs;
+  const ratio = totalDuration > 0 ? (nowMs - activeStart.getTime()) / totalDuration : 0;
+  const safeRatio = clamp01(ratio);
+
+  if (meta.fill) {
+    meta.fill.style.transform = `scaleX(${safeRatio})`;
+  }
+  if (meta.pct) {
+    meta.pct.textContent = `${(Math.round(safeRatio * 1000) / 10).toFixed(1)}%`;
+  }
+  if (meta.elapsed) {
+    meta.elapsed.textContent = elapsed < 0 ? '未开始' : humanizeDuration(elapsed);
+  }
+  if (meta.remain) {
+    meta.remain.textContent = remain < 0 ? '已结束' : humanizeDuration(remain);
+  }
+  if (meta.total) {
+    meta.total.textContent = totalText;
+  }
+
+  const statusText = STATE_BADGE_LABELS[state] ?? STATE_BADGE_LABELS.before;
+  if (statusBadge) {
+    statusBadge.textContent = statusText;
+  }
+  setRingProgress(ring, ratio, statusText);
+
+  const headline = getHeadline(event, state);
+  if (pageTitle) {
+    pageTitle.textContent = headline;
+  }
+
+  if (activeTitle) {
+    document.title = `${activeTitle} · ${statusText}`;
+  }
 }


### PR DESCRIPTION
## Summary
- add pure helpers for day boundaries, range status, and holiday ranges
- build shared event constructors and state-based copy for New Year, Golden Week, and next Sunday
- drive homepage and panel with a single tick that switches events and messaging automatically

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e5f1293f888324b1eb317ed057b2d3