### PR TITLE
Add live clock and Sunday sidebar card

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,23 +33,27 @@
       </div>
       <div class="drawer-body">
         <section class="drawer-section">
-          <h3 class="drawer-group">节日</h3>
-          <div class="panel-card">
+          <h3 class="drawer-group">常驻</h3>
+          <section class="panel-card" id="cardNewYear" aria-live="polite">
             <div class="panel-card-title">元旦</div>
-            <div id="nyValue" class="panel-card-value" aria-live="polite">--</div>
+            <div id="nyValue" class="panel-card-value">--</div>
             <div id="nyDesc" class="panel-card-desc">--</div>
-          </div>
+          </section>
+          <section class="panel-card" id="cardSunday" aria-live="polite">
+            <div class="card-title panel-card-title">下次周日</div>
+            <div class="card-main panel-card-value" id="sunValue">—</div>
+            <div class="card-sub panel-card-desc" id="sunDesc">—</div>
+          </section>
         </section>
       </div>
     </aside>
 
     <main class="card">
       <div class="topline">
-        <div class="range">
-          <div>开始：<strong id="startLabel"></strong></div>
-          <div>结束：<strong id="endLabel"></strong></div>
+        <div class="meta">
+          <span>当前：</span><span id="nowClock">--</span>
+          <span class="status-pill" id="statusPill">等待</span>
         </div>
-        <div class="badge" id="statusBadge">等待</div>
       </div>
 
       <section class="countdown" aria-live="polite">
@@ -62,10 +66,12 @@
       <section class="progress">
         <div class="bar" aria-label="假期进度"><div class="fill" id="fill"></div></div>
         <div class="meta">
+          <div>开始：<strong id="startLabel"></strong></div>
+          <div>结束：<strong id="endLabel"></strong></div>
+          <div>总时长：<strong id="total">--</strong></div>
           <div>已过：<strong id="pct">0%</strong></div>
           <div>已用时：<strong id="elapsed">--</strong></div>
           <div>剩余：<strong id="remain">--</strong></div>
-          <div>总时长：<strong id="total">--</strong></div>
         </div>
       </section>
 

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,14 +1,33 @@
 import { initThemePicker } from './theme.js';
 import { renderCountdown } from './countdown.js';
 import { buildGoldenWeek } from '../config/events.js';
-import { initDrawer, renderSidebar } from './sidebar.js';
+import { initDrawer, renderNewYearCard, renderSunday } from './sidebar.js';
+import { elements } from './dom.js';
+
+const formatClock = (date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+};
+
+function updateClock(now) {
+  const { clock } = elements;
+  if (!clock || !clock.now) return;
+  clock.now.textContent = formatClock(now);
+}
 
 function createTick() {
   return () => {
     const now = new Date();
+    updateClock(now);
     const event = buildGoldenWeek(now);
     renderCountdown(event, now);
-    renderSidebar(now);
+    renderNewYearCard(now);
+    renderSunday(now);
   };
 }
 

--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -225,7 +225,7 @@ export function renderCountdown(event, now = new Date()) {
 
   const current = now instanceof Date ? now : new Date(now);
   const nowMs = current.getTime();
-  const { digits, meta, statusBadge, ring, pageTitle } = elements;
+  const { digits, meta, statusPill, ring, pageTitle } = elements;
 
   const status = rangeStatus(current, { start: activeStart, end: activeEnd });
   const state = status.state;
@@ -277,8 +277,8 @@ export function renderCountdown(event, now = new Date()) {
   }
 
   const statusText = STATE_BADGE_LABELS[state] ?? STATE_BADGE_LABELS.before;
-  if (statusBadge) {
-    statusBadge.textContent = statusText;
+  if (statusPill) {
+    statusPill.textContent = statusText;
   }
   setRingProgress(ring, ratio, statusText);
 

--- a/scripts/dom.js
+++ b/scripts/dom.js
@@ -16,7 +16,7 @@ export const elements = {
     start: document.getElementById('startLabel'),
     end: document.getElementById('endLabel'),
   },
-  statusBadge: document.getElementById('statusBadge'),
+  statusPill: document.getElementById('statusPill'),
   ring: {
     arc: document.getElementById('arc'),
     head: document.getElementById('arcHead'),
@@ -34,8 +34,13 @@ export const elements = {
     backdrop: document.getElementById('backdrop'),
     button: document.getElementById('btn-drawer'),
   },
+  clock: {
+    now: document.getElementById('nowClock'),
+  },
   panel: {
     nyValue: document.getElementById('nyValue'),
     nyDesc: document.getElementById('nyDesc'),
+    sunValue: document.getElementById('sunValue'),
+    sunDesc: document.getElementById('sunDesc'),
   },
 };

--- a/scripts/sidebar.js
+++ b/scripts/sidebar.js
@@ -1,5 +1,5 @@
 import { elements } from './dom.js';
-import { formatDuration, formatShanghai, rangeStatus } from '../utils/time.js';
+import { formatDuration, formatShanghai, nextSundayRange, rangeStatus } from '../utils/time.js';
 import { buildNewYear } from '../config/events.js';
 
 const NY_MESSAGES = {
@@ -80,7 +80,7 @@ export function initDrawer() {
   });
 }
 
-export function renderSidebar(now) {
+export function renderNewYearCard(now) {
   const { panel } = elements;
   if (!panel) return;
 
@@ -97,4 +97,28 @@ export function renderSidebar(now) {
   const descPrefix = status.state === 'before' ? '开始' : '结束';
   const descDate = status.state === 'before' ? event.start : event.end;
   setText(panel.nyDesc, `${descPrefix}：${toLabel(descDate)}`);
+}
+
+export function renderSunday(now) {
+  const { panel } = elements;
+  if (!panel) return;
+
+  const current = now instanceof Date ? now : new Date(now);
+  const range = nextSundayRange(current);
+
+  if (range.state === 'during') {
+    const remainMs = Math.max(0, range.end.getTime() - current.getTime());
+    setText(panel.sunValue, `放假中（周日），距离结束还有 ${formatDuration(remainMs)}`);
+    setText(panel.sunDesc, `结束：${toLabel(range.end)}`);
+    return;
+  }
+
+  const untilStart = Math.max(0, range.start.getTime() - current.getTime());
+  setText(panel.sunValue, `距离下次周日还有 ${formatDuration(untilStart)}`);
+  setText(panel.sunDesc, `开始：${toLabel(range.start)}`);
+}
+
+export function renderSidebar(now) {
+  renderNewYearCard(now);
+  renderSunday(now);
 }

--- a/styles/main.css
+++ b/styles/main.css
@@ -177,23 +177,10 @@ header h1 {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 16px;
-  margin-bottom: 10px;
-  flex-wrap: nowrap;
-  overflow: hidden;
+  margin-bottom: 12px;
 }
 
-.range {
-  color: var(--muted);
-  font-size: 14px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px 16px;
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.badge {
+.status-pill {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -293,7 +280,7 @@ body.bg-fading,
 body.bg-fading .card,
 body.bg-fading .unit,
 body.bg-fading .panel,
-body.bg-fading .badge,
+body.bg-fading .status-pill,
 body.bg-fading .preview,
 body.bg-fading .bar,
 body.bg-fading .fill {
@@ -304,8 +291,11 @@ body.bg-fading .fill {
 /* 如果你手机上依旧稳定，不禁用也行 */
 /* （本包已去掉这段，避免误杀阴影） */
 
+.topline .meta {
+  margin: 0;
+}
+
 .meta {
-  margin-top: 10px;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -317,6 +307,10 @@ body.bg-fading .fill {
 
 .meta strong {
   color: inherit;
+}
+
+.progress .meta {
+  margin-top: 10px;
 }
 
 .grid {
@@ -673,7 +667,7 @@ body,
 .card,
 .unit,
 .panel,
-.badge,
+.status-pill,
 .preview,
 .bar,
 .fill {
@@ -745,16 +739,10 @@ body,
   }
 
   .topline {
-    gap: 28px;
-    margin-bottom: 18px;
+    margin-bottom: 20px;
   }
 
-  .range {
-    font-size: 15px;
-    gap: 12px 22px;
-  }
-
-  .badge {
+  .status-pill {
     font-size: 15px;
     padding: 8px 18px;
   }
@@ -786,6 +774,10 @@ body,
   .meta {
     font-size: 14px;
     gap: 14px 28px;
+  }
+
+  .progress .meta {
+    margin-top: 14px;
   }
 
   .grid {

--- a/utils/time.js
+++ b/utils/time.js
@@ -62,6 +62,23 @@ export function addDays(date, amount) {
   return new Date(ms + amount * DAY);
 }
 
+export function nextSundayRange(now = new Date()) {
+  const current = new Date(toTimestamp(now) ?? Date.now());
+  const shanghaiNow = new Date(current.getTime() + SHANGHAI_OFFSET_MIN * MIN);
+  const dayOfWeek = shanghaiNow.getUTCDay();
+  const start = startOfDay(current);
+
+  if (dayOfWeek === 0) {
+    const end = addDays(start, 1);
+    return { state: 'during', start, end, target: end };
+  }
+
+  const daysUntilSunday = 7 - dayOfWeek;
+  const sundayStart = addDays(start, daysUntilSunday);
+  const sundayEnd = addDays(sundayStart, 1);
+  return { state: 'before', start: sundayStart, end: sundayEnd, target: sundayStart };
+}
+
 export function rangeStatus(now, range) {
   const nowMs = toTimestamp(now) ?? Date.now();
   const startMs = toTimestamp(range.start);


### PR DESCRIPTION
## Summary
- show the current clock and status pill in the main countdown header while keeping event timing details in the stats block
- refresh sidebar cards each tick, including a new weekly "next Sunday" card based on a shared time utility
- update shared DOM helpers and styles to support the new widgets without changing the existing countdown flow

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e61a07989c8324bf8e96150c91c913