### PR TITLE
Ensure countdown uses Beijing timezone logic

### DIFF
--- a/config/events.js
+++ b/config/events.js
@@ -1,29 +1,21 @@
-import { MIN, SHANGHAI_OFFSET_MIN, goldenWeekRange, newYearRange } from '../utils/time.js';
-
-const toTimestamp = (value) => (value instanceof Date ? value.getTime() : Number(value) || Date.now());
-
-const getShanghaiYear = (now) => {
-  const timestamp = toTimestamp(now);
-  return new Date(timestamp + SHANGHAI_OFFSET_MIN * MIN).getUTCFullYear();
-};
+import { goldenWeekRangeBJT, newYearRangeBJT } from '../utils/time.js';
 
 export function buildGoldenWeek(now = new Date()) {
-  const year = getShanghaiYear(now);
-  const { start, end } = goldenWeekRange(year);
+  const range = goldenWeekRangeBJT(now);
   return {
     id: 'golden-week',
     title: '国庆·中秋',
-    start,
-    end,
+    start: range.start,
+    end: range.end,
   };
 }
 
 export function buildNewYear(now = new Date()) {
-  const { start, end } = newYearRange(now);
+  const range = newYearRangeBJT(now);
   return {
     id: 'new-year',
     title: '元旦',
-    start,
-    end,
+    start: range.start,
+    end: range.end,
   };
 }

--- a/index.html
+++ b/index.html
@@ -33,11 +33,27 @@
       </div>
       <div class="drawer-body">
         <section class="drawer-section">
+          <h3 class="drawer-group">当前</h3>
+          <div class="panel-card">
+            <div class="panel-card-title">北京时间</div>
+            <div id="nowClock" class="panel-card-value" aria-live="polite">当前：--</div>
+            <div class="panel-card-desc">固定 UTC+08:00</div>
+          </div>
+        </section>
+        <section class="drawer-section">
           <h3 class="drawer-group">节日</h3>
           <div class="panel-card">
             <div class="panel-card-title">元旦</div>
             <div id="nyValue" class="panel-card-value" aria-live="polite">--</div>
             <div id="nyDesc" class="panel-card-desc">--</div>
+          </div>
+        </section>
+        <section class="drawer-section">
+          <h3 class="drawer-group">休息日</h3>
+          <div class="panel-card">
+            <div class="panel-card-title">下次周日</div>
+            <div id="sunValue" class="panel-card-value" aria-live="polite">--</div>
+            <div id="sunDesc" class="panel-card-desc">--</div>
           </div>
         </section>
       </div>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,11 +1,12 @@
 import { initThemePicker } from './theme.js';
 import { renderCountdown } from './countdown.js';
 import { buildGoldenWeek } from '../config/events.js';
-import { initDrawer, renderSidebar } from './sidebar.js';
+import { initDrawer, renderSidebar, updateClock } from './sidebar.js';
 
 function createTick() {
   return () => {
     const now = new Date();
+    updateClock(now);
     const event = buildGoldenWeek(now);
     renderCountdown(event, now);
     renderSidebar(now);

--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -1,5 +1,5 @@
 import { elements } from './dom.js';
-import { breakdownDuration, humanizeDuration, formatShanghai, rangeStatus } from '../utils/time.js';
+import { breakdownDuration, humanizeDuration, formatBJT, rangeStatus } from '../utils/time.js';
 
 const RADIUS = 52;
 const RING_LENGTH = 2 * Math.PI * RADIUS;
@@ -208,10 +208,10 @@ function ensureEvent(event) {
   });
 
   if (labels.start) {
-    labels.start.textContent = formatShanghai(activeStart);
+    labels.start.textContent = formatBJT(activeStart);
   }
   if (labels.end) {
-    labels.end.textContent = formatShanghai(activeEnd);
+    labels.end.textContent = formatBJT(activeEnd);
   }
   if (meta.total) {
     meta.total.textContent = totalText;
@@ -241,8 +241,13 @@ export function renderCountdown(event, now = new Date()) {
   const elapsedMs = Math.max(0, nowMs - activeStart.getTime());
   const untilStartMs = Math.max(0, activeStart.getTime() - nowMs);
   const remainMs = Math.max(0, activeEnd.getTime() - nowMs);
-  const rawRatio = status.ratio ?? 0;
-  const ratio = state === 'after' ? 1 : Math.min(1, Math.max(0, rawRatio));
+  const totalMs = Math.max(0, activeEnd.getTime() - activeStart.getTime());
+  let ratio = 0;
+  if (state === 'after') {
+    ratio = 1;
+  } else if (state === 'during' && totalMs > 0) {
+    ratio = Math.min(1, Math.max(0, elapsedMs / totalMs));
+  }
 
   if (meta.fill) {
     meta.fill.style.transform = `scaleX(${ratio})`;

--- a/scripts/dom.js
+++ b/scripts/dom.js
@@ -35,7 +35,10 @@ export const elements = {
     button: document.getElementById('btn-drawer'),
   },
   panel: {
+    nowClock: document.getElementById('nowClock'),
     nyValue: document.getElementById('nyValue'),
     nyDesc: document.getElementById('nyDesc'),
+    sunValue: document.getElementById('sunValue'),
+    sunDesc: document.getElementById('sunDesc'),
   },
 };


### PR DESCRIPTION
## Summary
- add Beijing time utilities that use Asia/Shanghai for formatting and day boundaries
- update the countdown and sidebar to rely on the new utilities and render Beijing-standard timestamps
- extend the sidebar with Beijing time, New Year, and next Sunday status cards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e61ecec20c8324980f9ad2d77bd320