### PR TITLE
Set Golden Week countdown to end at 2025-10-08 23:59:59

### DIFF
--- a/utils/time.js
+++ b/utils/time.js
@@ -62,8 +62,11 @@ export function bjtAddDaysUTC(date, n) {
 }
 
 export function goldenWeekRangeBJT(now = new Date()) {
-  const y = bjtParts(now).y;
-  return { start: bjtLocalToUTC(y, 10, 1), end: bjtLocalToUTC(y, 10, 8) };
+  const targetYear = 2025;
+  return {
+    start: bjtLocalToUTC(targetYear, 10, 1),
+    end: bjtLocalToUTC(targetYear, 10, 8, 23, 59, 59),
+  };
 }
 
 export function newYearRangeBJT(now = new Date()) {


### PR DESCRIPTION
## Summary
- update the Golden Week countdown configuration to end at 2025-10-08 23:59:59 Beijing time

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6390af6c88324be24f6e4b75ae707