### PR TITLE
Update holiday headline text during event

### DIFF
--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -14,7 +14,7 @@ const STATE_BADGE_LABELS = {
 
 const HOME_HEADLINES = {
   before: '距离国庆·中秋还有',
-  during: '国庆·中秋假期中，距离结束还有',
+  during: '国庆·中秋',
   after: '距离国庆·中秋结束已经过去',
 };
 


### PR DESCRIPTION
## Summary
- shorten the during-state headline to display "国庆·中秋"

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e63ddd53e48324bffe4f2368e2d81f