### PR TITLE
Prevent duplicate headline in browser title

### DIFF
--- a/scripts/countdown.js
+++ b/scripts/countdown.js
@@ -14,7 +14,7 @@ const STATE_BADGE_LABELS = {
 
 const HOME_HEADLINES = {
   before: '距离国庆·中秋还有',
-  during: '国庆·中秋假期中，距离结束还有',
+  during: '国庆·中秋',
   after: '距离国庆·中秋结束已经过去',
 };
 
@@ -292,7 +292,7 @@ export function renderCountdown(event, now = new Date()) {
     pageTitle.textContent = headline;
   }
 
-  if (activeTitle) {
+  if (activeTitle && activeTitle.trim() && activeTitle.trim() !== headline.trim()) {
     document.title = `${headline} · ${activeTitle}`;
   } else {
     document.title = headline;


### PR DESCRIPTION
## Summary
- avoid appending the event title to the document title when it matches the active headline so the tab shows "国庆·中秋"

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68e63ddd53e48324bffe4f2368e2d81f